### PR TITLE
Trust notebooks and add jupyterlab extensions

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -8,3 +8,11 @@ jupyter nbextension enable rubberband/main
 jupyter nbextension enable exercise2/main
 jupyter nbextension enable collapsible_headings/main
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
+
+# Add jupyterlab extensions
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyter-leaflet
+
+# Ensure we trust all the notebooks
+jupyter trust *.ipynb
+


### PR DESCRIPTION
Trust notebooks and add jupyterlab extensions. If running `repo2docker`, `postBuild` sets up all the jupyter config/extensions.